### PR TITLE
ID:8570 Hotfix: avoid approved talks

### DIFF
--- a/lib/Foswiki/Plugins/KVPPlugin.pm
+++ b/lib/Foswiki/Plugins/KVPPlugin.pm
@@ -2861,6 +2861,49 @@ sub maintenanceHandler {
             return $error;
         }
     });
+    Foswiki::Plugins::MaintenancePlugin::registerCheck("KVPPlugin:TalksInApprovedState", {
+        name => "KVPPlugin: approved discussions",
+        description => "The following discussions kept approved state.",
+        check => sub {
+
+            sub _getProcessesWebs {
+                my @processesWebs = ();
+                foreach my $web ( Foswiki::Func::getPublicWebList() ) {
+                    my $defaultSources = Foswiki::Func::getPreferencesValue( 'DEFAULT_SOURCES', $web ) || "";
+                    push(@processesWebs, $web) if( $defaultSources =~ m#\bProcessesContentContrib\b# );
+                }
+                return @processesWebs;
+            }
+
+            sub _getTalks {
+                my $processesWeb = shift;
+                my @talks = ();
+                @talks = grep(/TALK$/, Foswiki::Func::getTopicList( $processesWeb ));
+                return @talks;
+            }
+
+            my @approvedTalks = ();
+
+            foreach my $processesWeb ( _getProcessesWebs() ) {
+                foreach my $talk ( _getTalks( $processesWeb ) ){
+                    my ( $meta, $text ) = Foswiki::Func::readTopic($processesWeb, $talk);
+                    if($meta->{'WORKFLOW'} && $meta->{'WORKFLOW'}[0]->{'name'} && $meta->{'WORKFLOW'}[0]->{'name'} =~ m#APPROVED# ){
+                        push(@approvedTalks, "[[$processesWeb.$talk][$processesWeb.$talk]]");
+                    }
+                }
+            }
+
+            if( @approvedTalks ){
+                return {
+                    result => 1,
+                    priority => $Foswiki::Plugins::MaintenancePlugin::CRITICAL,
+                    solution => "Compare the following TALKs to the approved topics and either remove the TALK or change <code>%META:WORKFLOW{name=\"APPROVED\"</code> to <code>%META:WORKFLOW{name=\"DISCUSSION\"</code>:<br>".join("<br>",@approvedTalks)
+                };
+            }
+            return { result => 0 };
+        }
+    });
+
 }
 
 1;

--- a/lib/Foswiki/Plugins/KVPPlugin/Workflow.pm
+++ b/lib/Foswiki/Plugins/KVPPlugin/Workflow.pm
@@ -419,7 +419,7 @@ sub getNextState {
     my $t = $this->getTransition($currentState, $action);
     return undef unless $t;
 
-    unless($t->{attribute} && $t->{attribute} =~ m#\bIGNOREMANDATORY\b#) {
+    unless($t->{attribute} && ( $t->{attribute} =~ m#\bIGNOREMANDATORY\b# || $t->{attribute} =~ m#\bFORK\b# )) {
         return undef if scalar Foswiki::Plugins::ModacHelpersPlugin::getNonSatisfiedFormFields($topic->{meta});
     }
 


### PR DESCRIPTION
id: 8570
When mandatory formfields are missing in an approved topic a discussion
remains in the approved state, though the TALK file is created. Ignoring
the mandatory fields on FORK allows proper states and forces the next
editor to fix missing form fields. The fix also provides a
MaintenanceCheck to discover broken Talks but no automated repair.